### PR TITLE
Fix incorrect bit length formula

### DIFF
--- a/psi_analytics_eurocrypt19/common/psi_analytics.cpp
+++ b/psi_analytics_eurocrypt19/common/psi_analytics.cpp
@@ -97,7 +97,7 @@ uint64_t run_psi_analytics(const std::vector<std::uint64_t> &inputs, PsiAnalytic
   }
 
   share_ptr s_out;
-  auto t_bitlen = static_cast<std::size_t>(std::ceil(std::log2(context.threshold)));
+  auto t_bitlen = static_cast<std::size_t>(std::ceil(std::log2(context.threshold + 1)));
   auto s_threshold = share_ptr(bc->PutCONSGate(context.threshold, t_bitlen));
   std::uint64_t const_zero = 0;
   auto s_zero = share_ptr(bc->PutCONSGate(const_zero, 1));


### PR DESCRIPTION
An incorrect bit length formula in *run_psi_analytics* causes the computation of `std::ceil(std::log2(0))` which equates U_LONG_MAX (**18446744073709551615** on my machine) when the example program is used with the default threshold 0 (or with `-c 0`. 
This value is then cast into a `uint32_t bitlen` i.e UINT_MAX (**4294967295** on my machine) in `BooleanCircuit::PutCONSGate`.
Finally `BooleanCircuit::PutSIMDCONSGate` iterates over `bitlen` resizing the vector `m_vGates` through `m_vGates` at each pass which ends up throwing a `bad_alloc`.